### PR TITLE
v0.3: non-English resume filenames (ask the user when discover-resume misses)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to resumasher will be captured here. Format loosely follows 
 
 ## [Unreleased]
 
-Nothing queued.
+### Added
+
+- **Non-English resume filenames** ([#3](https://github.com/earino/resumasher/issues/3)). A student whose resume is saved as `Lebenslauf.md`, `curriculum.md`, `cv_francais.md`, `履歴書.md`, `简历.md`, or `my_resume_final_v3.md` no longer hits "FAILURE: no resume found" as a terminal error. When `discover-resume` misses, the skill falls through to asking the student "what's the filename?" via the cross-host question tool and validates the answer with a new `validate-resume-path` subcommand. Handles CJK characters, spaces, absolute paths, and subdirectory paths. Up to 3 re-ask attempts before giving up. No filename-list expansion, no directory scan, no LLM classification — one prompt.
 
 ## [0.2.0] — 2026-04-19
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -453,19 +453,35 @@ If `$GITHUB_USER` is set (either from config or the flag), the mine phase mixes 
 Locate the resume:
 
 ```bash
-"$RS" orchestration discover-resume "$STUDENT_CWD"
+RESUME_PATH=$("$RS" orchestration discover-resume "$STUDENT_CWD")
 ```
 
 `discover-resume` looks for (in priority order): `resume.md`, `resume.markdown`, `cv.md`, `CV.md`, `resume.pdf`, `Resume.pdf`, `cv.pdf`, `CV.pdf`. Markdown is preferred because it's source-of-truth and diff-friendly; PDF works when the student only has a PDF export. If both a `.md` and a `.pdf` exist, the `.md` wins.
 
-If this exits with a `FAILURE: no resume found` message, halt the skill with:
+**If `$RESUME_PATH` is empty (discover-resume exited with `FAILURE: no resume found`):** the fast path missed. Don't halt — a student whose resume is named `Lebenslauf.md` (German), `curriculum.md` (Spanish), `履歴書.md` (Japanese), `my_resume_final_v3.md`, or anything else outside the canonical English filename list is still a valid user. Fall through to asking.
 
-> resumasher needs a resume to work with. Please add a `resume.md`, `cv.md`, or `resume.pdf` to this folder and try again. You can use the skill's GOLDEN_FIXTURES/resume.md as a template.
+Use the platform's question tool (`AskUserQuestion` in Claude Code, `request_user_input` in Codex, `ask_user` in Gemini) with:
 
-Otherwise: read the resume.
+> I couldn't find a resume with one of the default filenames (resume.md, cv.md, resume.pdf, etc.) in this folder. What's the filename? Examples: `Lebenslauf.md`, `履歴書.md`, `my_resume.pdf`.
+
+Validate the student's answer with the `validate-resume-path` subcommand:
 
 ```bash
-RESUME_PATH=$("$RS" orchestration discover-resume "$STUDENT_CWD")
+RESUME_PATH=$("$RS" orchestration validate-resume-path "$STUDENT_CWD" "$STUDENT_ANSWER")
+```
+
+- Exits 0 and prints the absolute path on success.
+- Exits 1 and prints `FAILURE: <reason>` to stderr on failure (file doesn't exist, wrong extension, is a directory, unreadable).
+
+If validation fails, re-ask the student with a clearer error — e.g., "That file (`notes.docx`) has an unsupported extension. resumasher accepts `.md`, `.markdown`, and `.pdf`. What's the actual filename?"
+
+Give the student up to 3 attempts. If all 3 fail, halt with:
+
+> resumasher needs a resume to work with. Please add a `.md`, `.markdown`, or `.pdf` file to this folder and try again. You can use the skill's GOLDEN_FIXTURES/resume.md as a template.
+
+Once `$RESUME_PATH` is set (either from discover-resume or from the validated fallback), read the resume:
+
+```bash
 "$RS" orchestration read-resume "$RESUME_PATH" > $RUN_DIR/resume.txt
 ```
 

--- a/scripts/orchestration.py
+++ b/scripts/orchestration.py
@@ -113,6 +113,69 @@ def discover_resume(cwd: Path) -> Optional[Path]:
     return None
 
 
+ACCEPTED_RESUME_EXTENSIONS = frozenset({".md", ".markdown", ".pdf"})
+
+
+def validate_resume_path(cwd: Path, filename: str) -> tuple[Optional[Path], Optional[str]]:
+    """
+    Validate a student-provided resume filename and return (abs_path, None) if
+    acceptable, or (None, error_message) otherwise.
+
+    Used as the fallback when `discover_resume` returns None (e.g., the
+    student's file is named `Lebenslauf.md`, `履歴書.md`, `my_resume_v3.md`,
+    or anything else not in RESUME_CANDIDATES). The SKILL.md orchestrator
+    asks the student "what's the filename?" via the cross-host question tool
+    and feeds the response through this validator.
+
+    Accepts:
+    - A relative path (resolved against `cwd`).
+    - An absolute path (used as-is).
+    - Any Unicode filename including CJK characters, spaces, and hyphens.
+    - Extensions .md / .markdown / .pdf (case-insensitive).
+
+    Rejects:
+    - Files that don't exist.
+    - Files with unsupported extensions (.docx, .txt, .rtf, etc).
+    - Directories (even if the name looks like a resume).
+    - Paths the current process can't read.
+    """
+    if not filename or not filename.strip():
+        return None, "filename is empty"
+
+    filename = filename.strip()
+    # Accept both relative-to-cwd and absolute paths.
+    candidate = Path(filename) if Path(filename).is_absolute() else (cwd / filename)
+
+    # Resolve symlinks + ".." segments; works even if the file doesn't exist yet.
+    # (Path.resolve(strict=False) was added in 3.6; we target 3.10+.)
+    try:
+        candidate = candidate.resolve()
+    except (OSError, RuntimeError):
+        return None, f"could not resolve path: {filename}"
+
+    if not candidate.exists():
+        return None, f"file does not exist: {candidate}"
+    if not candidate.is_file():
+        return None, f"not a regular file (directory or special): {candidate}"
+
+    ext = candidate.suffix.lower()
+    if ext not in ACCEPTED_RESUME_EXTENSIONS:
+        accepted = ", ".join(sorted(ACCEPTED_RESUME_EXTENSIONS))
+        return None, (
+            f"unsupported extension {ext or '(none)'}: {candidate}. "
+            f"Accepted: {accepted}"
+        )
+
+    try:
+        # Probe readability without loading the whole file.
+        with candidate.open("rb") as f:
+            f.read(1)
+    except OSError as exc:
+        return None, f"file is not readable: {candidate} ({exc})"
+
+    return candidate, None
+
+
 # ---------------------------------------------------------------------------
 # 3. read file with encoding detection (chardet fallback to utf-8-sig / utf-8)
 # ---------------------------------------------------------------------------
@@ -662,6 +725,10 @@ def _cli() -> int:
     p = sub.add_parser("discover-resume")
     p.add_argument("cwd", nargs="?", default=".")
 
+    p = sub.add_parser("validate-resume-path")
+    p.add_argument("cwd")
+    p.add_argument("filename")
+
     p = sub.add_parser("folder-state-hash")
     p.add_argument("cwd", nargs="?", default=".")
 
@@ -766,6 +833,14 @@ def _cli() -> int:
                 + ": "
                 + ", ".join(RESUME_CANDIDATES)
             )
+            return 1
+        print(str(path))
+        return 0
+
+    if args.command == "validate-resume-path":
+        path, err = validate_resume_path(Path(args.cwd), args.filename)
+        if err is not None:
+            print(f"FAILURE: {err}", file=sys.stderr)
             return 1
         print(str(path))
         return 0

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -30,6 +30,7 @@ from scripts.orchestration import (
     parse_job_source,
     read_config,
     read_resume,
+    validate_resume_path,
     write_config,
 )
 
@@ -110,6 +111,113 @@ def test_discover_resume_accepts_cv_pdf_variants(tmp_path: Path):
     (tmp_path / "CV.pdf").write_bytes(b"%PDF-1.4\n...")
     result = discover_resume(tmp_path)
     assert result is not None and result.name == "CV.pdf"
+
+
+# ---------------------------------------------------------------------------
+# validate_resume_path: fallback when discover_resume misses
+# ---------------------------------------------------------------------------
+# Added in v0.3 (issue #3) for non-English-filename students: Lebenslauf.md,
+# 履歴書.md, curriculum.md, my_resume_final_v3.md, etc. The SKILL.md orchestrator
+# asks the student "what's the filename?" via the cross-host question tool
+# and feeds the response through this validator.
+
+
+def test_discover_resume_unchanged_behavior_non_english(tmp_path: Path):
+    """Documentary: discover_resume still returns None for non-English names.
+    This is intentional — the fallback-and-ask logic lives in SKILL.md."""
+    (tmp_path / "Lebenslauf.md").write_text("# Bewerbung", encoding="utf-8")
+    assert discover_resume(tmp_path) is None
+
+
+def test_validate_resume_path_accepts_german_filename(tmp_path: Path):
+    (tmp_path / "Lebenslauf.md").write_text("# Bewerbung", encoding="utf-8")
+    path, err = validate_resume_path(tmp_path, "Lebenslauf.md")
+    assert err is None
+    assert path is not None and path.name == "Lebenslauf.md"
+
+
+def test_validate_resume_path_accepts_cjk_filename(tmp_path: Path):
+    """CJK characters in filenames must round-trip cleanly."""
+    (tmp_path / "履歴書.md").write_text("# 職務経歴書", encoding="utf-8")
+    path, err = validate_resume_path(tmp_path, "履歴書.md")
+    assert err is None
+    assert path is not None and path.name == "履歴書.md"
+
+
+def test_validate_resume_path_accepts_name_with_spaces(tmp_path: Path):
+    """my_resume_final_FINAL_v3.md is a real filename students pick."""
+    (tmp_path / "my resume final v3.md").write_text("# Me", encoding="utf-8")
+    path, err = validate_resume_path(tmp_path, "my resume final v3.md")
+    assert err is None
+    assert path is not None and "my resume final v3.md" in str(path)
+
+
+def test_validate_resume_path_accepts_absolute_path(tmp_path: Path):
+    """A student can paste an absolute path instead of a relative filename."""
+    target = tmp_path / "Lebenslauf.md"
+    target.write_text("# Bewerbung", encoding="utf-8")
+    path, err = validate_resume_path(Path("/tmp"), str(target))
+    assert err is None
+    assert path == target.resolve()
+
+
+def test_validate_resume_path_rejects_nonexistent(tmp_path: Path):
+    path, err = validate_resume_path(tmp_path, "nonexistent.md")
+    assert path is None
+    assert err is not None and "does not exist" in err
+
+
+def test_validate_resume_path_rejects_wrong_extension(tmp_path: Path):
+    """A student typing `Lebenslauf.docx` gets a clear rejection."""
+    (tmp_path / "Lebenslauf.docx").write_text("garbage", encoding="utf-8")
+    path, err = validate_resume_path(tmp_path, "Lebenslauf.docx")
+    assert path is None
+    assert err is not None and "unsupported extension" in err
+    # Error message should name the accepted extensions so the student knows
+    # what to rename to.
+    assert ".md" in err and ".pdf" in err
+
+
+def test_validate_resume_path_rejects_directory_masquerading_as_file(tmp_path: Path):
+    """A directory named `resume.md` is not a resume, even though the name matches."""
+    (tmp_path / "resume.md").mkdir()
+    path, err = validate_resume_path(tmp_path, "resume.md")
+    assert path is None
+    assert err is not None and "not a regular file" in err
+
+
+def test_validate_resume_path_accepts_subdirectory_paths(tmp_path: Path):
+    """Students who keep resumes under `./documents/resume.md` should still work."""
+    subdir = tmp_path / "documents"
+    subdir.mkdir()
+    target = subdir / "Lebenslauf.md"
+    target.write_text("# Bewerbung", encoding="utf-8")
+    path, err = validate_resume_path(tmp_path, "documents/Lebenslauf.md")
+    assert err is None
+    assert path is not None and path.name == "Lebenslauf.md"
+
+
+def test_validate_resume_path_rejects_empty_filename(tmp_path: Path):
+    """An empty answer from the student should produce a clear error, not a crash."""
+    path, err = validate_resume_path(tmp_path, "")
+    assert path is None
+    assert err is not None and "empty" in err
+
+
+def test_validate_resume_path_accepts_markdown_extension(tmp_path: Path):
+    """The rarer `.markdown` extension is also valid (matches RESUME_CANDIDATES)."""
+    (tmp_path / "cv.markdown").write_text("# Me", encoding="utf-8")
+    path, err = validate_resume_path(tmp_path, "cv.markdown")
+    assert err is None
+    assert path is not None
+
+
+def test_validate_resume_path_accepts_uppercase_extension(tmp_path: Path):
+    """Extension matching is case-insensitive — `RESUME.PDF` is fine."""
+    (tmp_path / "RESUME.PDF").write_bytes(b"%PDF-1.4\n...")
+    path, err = validate_resume_path(tmp_path, "RESUME.PDF")
+    assert err is None
+    assert path is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3.

## Summary

Students whose resume files aren't named with an English canonical pattern (`Lebenslauf.md`, `curriculum.md`, `履歴書.md`, `简历.md`, `my_resume_final_v3.md`, …) no longer get `FAILURE: no resume found` as a terminal error. When `discover-resume` misses, the skill falls through to asking "what's the filename?" via the cross-host question tool and validates the answer.

## What changed

**`scripts/orchestration.py`**
- New `validate_resume_path(cwd, filename)` function returning `(abs_path, err)`.
- New `validate-resume-path <cwd> <filename>` CLI subcommand (exit 0 + abs path on success, exit 1 + clear error on failure).
- Accepts `.md` / `.markdown` / `.pdf` case-insensitively. Handles CJK characters, spaces, absolute paths, and subdirectory paths (`documents/Lebenslauf.md`).
- Rejects: nonexistent files, directories masquerading as files, unsupported extensions (`.docx`, `.txt`, etc), empty input, unreadable files.

**`SKILL.md` Phase 2**
- `discover-resume` still runs first (fast path for the 80% case).
- If it returns empty, the orchestrator now asks the student directly, validates their answer with `validate-resume-path`, and re-asks on failure with a clearer error.
- Up to 3 attempts before giving up. On failure, falls back to the original halt message pointing at `GOLDEN_FIXTURES/resume.md`.

## Design rationale (copied from issue)

- **vs. expanding `RESUME_CANDIDATES`:** any list is incomplete. Adding `Lebenslauf.md`, `履歴書.md`, etc. still misses dozens of languages and filenames like `my_resume_final_v3.md` that don't match any canonical pattern.
- **vs. scanning the directory:** adds code for the rare case, requires disambiguation UX, doesn't help in the common case. Asking is simpler than guessing.
- **vs. LLM content-glance:** adds a round-trip and latency to first-run for 99% of users who don't need it.

## Tests

216 total (was 204 on main, +12 for this PR).

New tests cover:
- `discover_resume` unchanged: English filenames still return; non-English names still return None (documentary — the fallback lives in SKILL.md).
- `validate_resume_path` accepts: German, CJK (`履歴書.md`), spaces (`my resume final v3.md`), absolute paths, subdirectory paths, `.markdown` extension, uppercase extensions (`RESUME.PDF`).
- `validate_resume_path` rejects with clear errors: nonexistent, wrong extension (`.docx`), directory masquerading as file, empty string.

## Test plan

- [x] `pytest tests/ -q` — 216 passing
- [x] Manually verified CLI: `python -m scripts.orchestration validate-resume-path /tmp/test "履歴書.md"` → returns absolute path; `.docx` → rejected with accepted-extensions list.
- [ ] Live test on a fresh checkout with a non-English-named resume to confirm the SKILL.md fallback flow works cross-host.

## Out of scope

- OCR for image-only PDFs (separate problem)
- Resume-vs-cover-letter disambiguation (separate problem)
- Auto-translation of non-English resumes (feature creep — resumasher tailors, doesn't translate)
- Teaching students to name their resume `resume.md` for the fast path (this is a tool problem, not a user-education problem)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
