### PR TITLE
Add back-to-home link on stats page

### DIFF
--- a/stats.md
+++ b/stats.md
@@ -5,6 +5,8 @@ description: Aggregate metrics from resumasher installs that opted into communit
 permalink: /stats/
 ---
 
+<a href="/resumasher/" style="font-size:0.85rem;color:var(--muted);text-decoration:none;">&larr; Back to resumasher</a>
+
 # Community stats
 
 <p>Aggregate data from resumasher installs that opted into the community


### PR DESCRIPTION
## Summary
- Adds a subtle "← Back to resumasher" link at the top of the stats page, linking back to `/resumasher/`
- Styled small and muted to match the page aesthetic

## Test plan
- [ ] Visit https://earino.github.io/resumasher/stats/ after deploy
- [ ] Verify the link navigates to https://earino.github.io/resumasher/

🤖 Generated with [Claude Code](https://claude.com/claude-code)