### PR TITLE
feat: persist JD to application folder as jd.md (closes #15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to resumasher will be captured here. Format loosely follows 
 
 ## [Unreleased]
 
+### Added
+
+- **Persist JD to application folder as `jd.md`** ([#15](https://github.com/earino/resumasher/issues/15)). The job description now lands in `applications/<slug>-<date>/jd.md` alongside the other artifacts, so students can re-read the exact wording of a requirement, open it next to `interview-prep.md`, or grab the source URL for a recruiter follow-up — weeks after the run, and even after the `.resumasher/run/` scratch directory has been wiped by subsequent runs. Done at Phase 3 (right after `mkdir -p "$OUT_DIR"`) rather than Phase 9, so the JD survives even if a later phase (tailor, PDF render) hard-stops. For URL-mode inputs, a `Source URL: <url>` header is prepended by a new `format-jd` orchestration subcommand at Phase 1, so the posting URL is preserved into `jd.md` even if the posting page is later taken down. File-mode and literal-mode inputs carry no URL (nothing to preserve). First v0.4 feature shaped by actual cohort feedback (h/t @b0glarka).
+
 ## [0.3.0] — 2026-04-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/earino/resumasher/actions/workflows/ci.yml/badge.svg)](https://github.com/earino/resumasher/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/earino/resumasher/blob/main/LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
-[![Tests: 220 passing](https://img.shields.io/badge/tests-220%20passing-brightgreen.svg)](https://github.com/earino/resumasher/tree/main/tests)
+[![Tests: 233 passing](https://img.shields.io/badge/tests-233%20passing-brightgreen.svg)](https://github.com/earino/resumasher/tree/main/tests)
 
 resumasher tailors your resume, writes a cover letter, and builds an interview prep bundle for a specific job. It runs as an [Agent Skill](https://github.com/anthropics/skills) inside your AI CLI (**Claude Code**, **OpenAI Codex CLI**, or **Google Gemini CLI**), reading your actual work to back every claim with concrete evidence.
 
@@ -329,7 +329,7 @@ resumasher telemetry set-tier anonymous # Change tier
 ## Development
 
 ```bash
-# Run the test suite (220 tests, ~4 seconds)
+# Run the test suite (233 tests, ~4 seconds)
 source .venv/bin/activate
 pytest tests/ -v
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -405,17 +405,26 @@ rm -rf "$RUN_DIR"
 mkdir -p "$RUN_DIR"
 ```
 
-Parse the job source and save the JD text to `$RUN_DIR/jd.txt` (later phases — fit-analyst, tailor, cover-letter, interview-coach — read from that path):
+Parse the job source and save the JD text to `$RUN_DIR/jd.txt` (later phases — fit-analyst, tailor, cover-letter, interview-coach — read from that path, and Phase 3 copies the file to `$OUT_DIR/jd.md` for the student's records):
 
 ```bash
 "$RS" orchestration parse-job-source "$JOB_SOURCE_ARG"
-# Persist the JD content to $RUN_DIR/jd.txt from the "content" field of the
-# returned JSON, OR, if mode=="url", after you've fetched the page text.
+# Returns JSON: {"mode": "file|url|literal", "path": "...", "content": "..."}
 ```
 
-This returns JSON: `{"mode": "file|url|literal", "path": "...", "content": "..."}`.
+Route the write through `format-jd` so the Source URL header is prepended for URL-mode inputs (matters for `applications/<slug>/jd.md`: students recovering an old run need the URL for recruiter follow-up even after the posting is taken down). Pass the content via stdin:
 
-If `mode == "url"`: fetch the page with the WebFetch tool (Claude Code) or the equivalent `web_fetch` tool (Gemini) / curl-via-Bash (Codex, which conflates fetch with search). If the returned text is shorter than 500 characters or clearly a login wall (contains "Sign in", "Log in", or similar without the JD content), prompt the student via the platform's question tool (`AskUserQuestion` in Claude Code, `request_user_input` in Codex, `ask_user` in Gemini) to paste the JD text manually, then treat the response as `mode: "literal"`.
+```bash
+# mode=file or mode=literal — content comes straight from parse-job-source:
+echo -n "$CONTENT" | "$RS" orchestration format-jd --mode "$MODE" > "$RUN_DIR/jd.txt"
+
+# mode=url — fetch the page FIRST, then pipe the fetched text with --url set:
+echo -n "$FETCHED_PAGE_TEXT" | "$RS" orchestration format-jd --mode url --url "$URL" > "$RUN_DIR/jd.txt"
+```
+
+`format-jd` is a pure transform — it takes the raw content on stdin, prepends `Source URL: <url>\n\n` when `mode=url`, and emits the final bytes on stdout. File and literal modes pass through unchanged. If `--url` is omitted under `mode=url`, the prepend is skipped (defensive fallback — better to ship an un-headered JD than crash).
+
+If `mode == "url"`: fetch the page with the WebFetch tool (Claude Code) or the equivalent `web_fetch` tool (Gemini) / curl-via-Bash (Codex, which conflates fetch with search). If the returned text is shorter than 500 characters or clearly a login wall (contains "Sign in", "Log in", or similar without the JD content), prompt the student via the platform's question tool (`AskUserQuestion` in Claude Code, `request_user_input` in Codex, `ask_user` in Gemini) to paste the JD text manually, then treat the response as `mode: "literal"` (no `--url` needed in the format-jd call since the student's paste has no URL).
 
 **Language detection.** If the JD text is not English, block with a clear message: "resumasher v0.1 supports English JDs only. Detected: <lang>. Please paste an English translation and retry." (Use your own judgment to detect the language — no external detector needed.)
 
@@ -589,7 +598,10 @@ SLUG=$("$RS" orchestration company-slug "$COMPANY")
 DATE=$(date +%Y%m%d)
 OUT_DIR="$STUDENT_CWD/applications/$SLUG-$DATE"
 mkdir -p "$OUT_DIR"
+cp "$RUN_DIR/jd.txt" "$OUT_DIR/jd.md"
 ```
+
+The `cp` persists the JD (with Source URL header for URL-mode inputs) into the application folder. `$RUN_DIR/jd.txt` gets wiped at the start of every new run, so without this copy the JD is lost as soon as the student runs resumasher against a different posting. Doing the copy at Phase 3 rather than Phase 9 means the JD survives even if a later phase (company research, tailor, PDF render) hard-stops.
 
 Print the fit score to the terminal: `Fit score: $FIT_SCORE/10. Full assessment saved to $OUT_DIR/fit-assessment.md.`
 

--- a/scripts/orchestration.py
+++ b/scripts/orchestration.py
@@ -91,6 +91,29 @@ def parse_job_source(arg: str, cwd: Optional[Path] = None) -> JobSource:
     return JobSource(mode="literal", content=arg)
 
 
+def format_jd(mode: str, content: str, url: Optional[str] = None) -> str:
+    """
+    Format the JD text that gets written to $RUN_DIR/jd.txt and subsequently
+    copied to $OUT_DIR/jd.md in Phase 3.
+
+    For mode="url", prepend a `Source URL: <url>` header (followed by a blank
+    line) so the posting URL survives alongside the fetched page text. A
+    recruiter follow-up weeks after the application, or a re-read of the exact
+    posting phrasing, both need the URL, and the fetched page text alone drops
+    it (the URL is metadata, not content).
+
+    For mode="file" or mode="literal", return content unchanged — there's no
+    URL to preserve (file mode: the student already has the file; literal
+    mode: the JD was pasted inline).
+
+    If mode="url" is passed but url is None/empty, return content unchanged as
+    a defensive fallback — we'd rather ship an un-headered file than crash.
+    """
+    if mode == "url" and url:
+        return f"Source URL: {url}\n\n{content}"
+    return content
+
+
 # ---------------------------------------------------------------------------
 # 2. discover_resume: canonical filenames in priority order
 # ---------------------------------------------------------------------------
@@ -722,6 +745,15 @@ def _cli() -> int:
     p.add_argument("arg")
     p.add_argument("--cwd", default=".")
 
+    p = sub.add_parser("format-jd")
+    p.add_argument("--mode", required=True, choices=["file", "url", "literal"])
+    p.add_argument("--url", default=None, help="Source URL (for mode=url; prepended as a header line)")
+    p.add_argument(
+        "--content-file",
+        default="-",
+        help="Path to a file containing the JD text, or '-' for stdin (default).",
+    )
+
     p = sub.add_parser("discover-resume")
     p.add_argument("cwd", nargs="?", default=".")
 
@@ -822,6 +854,14 @@ def _cli() -> int:
     if args.command == "parse-job-source":
         res = parse_job_source(args.arg, cwd=Path(args.cwd))
         print(json.dumps({"mode": res.mode, "path": res.path, "content": res.content}))
+        return 0
+
+    if args.command == "format-jd":
+        if args.content_file == "-":
+            content = sys.stdin.read()
+        else:
+            content = Path(args.content_file).read_text(encoding="utf-8")
+        sys.stdout.write(format_jd(args.mode, content, args.url))
         return 0
 
     if args.command == "discover-resume":

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -25,6 +25,7 @@ from scripts.orchestration import (
     extract_fit_score,
     first_run_needed,
     folder_state_hash,
+    format_jd,
     is_failure_sentinel,
     mine_folder_context,
     parse_job_source,
@@ -68,6 +69,140 @@ def test_parse_job_source_handles_utf16_file(tmp_path: Path):
     res = parse_job_source("jd.md", cwd=tmp_path)
     assert res.mode == "file"
     assert "café" in res.content
+
+
+# ---------------------------------------------------------------------------
+# format_jd — persists JD to $RUN_DIR/jd.txt (and onward to $OUT_DIR/jd.md)
+#
+# Issue #15: students running resumasher against multiple postings were losing
+# the JD between runs (it only lived at $RUN_DIR/jd.txt, which gets wiped).
+# format_jd normalizes the write so Phase 3 can `cp` to $OUT_DIR/jd.md, and
+# adds a Source URL header for url-mode inputs so recruiter follow-ups still
+# work weeks later.
+# ---------------------------------------------------------------------------
+
+
+def test_format_jd_file_mode_passes_content_through():
+    """File mode: the JD text came from an existing file the student already
+    owns. No URL to preserve. Output matches input byte-for-byte."""
+    content = "# Senior Analyst\n\nResponsibilities: SQL, dashboards, stakeholder management.\n"
+    out = format_jd("file", content)
+    assert out == content
+
+
+def test_format_jd_literal_mode_passes_content_through():
+    """Literal mode: the student pasted the JD inline. No URL exists."""
+    content = "Junior Data Scientist at Acme. Python, SQL, some ML."
+    out = format_jd("literal", content)
+    assert out == content
+
+
+def test_format_jd_url_mode_prepends_source_url_header():
+    """URL mode: the fetched page text is the content; the URL itself is
+    metadata. Prepend it so Phase 3's cp carries the URL into jd.md."""
+    url = "https://company.com/careers/junior-data-scientist.html"
+    fetched_page = "Junior Data Scientist\n\nWe are looking for...\n"
+    out = format_jd("url", fetched_page, url=url)
+    assert out.startswith(f"Source URL: {url}\n\n")
+    assert fetched_page in out
+    # The header ends with exactly one blank line before the fetched content.
+    assert out == f"Source URL: {url}\n\n{fetched_page}"
+
+
+def test_format_jd_url_mode_without_url_arg_defensive_fallback():
+    """If the caller passes mode=url but forgets --url (shouldn't happen, but
+    we'd rather return un-headered content than crash)."""
+    content = "Fetched job description text."
+    out = format_jd("url", content, url=None)
+    assert out == content  # No prepend when url is None.
+
+
+def test_format_jd_url_mode_with_empty_url_defensive_fallback():
+    """Same defensive behavior for empty-string url."""
+    content = "Fetched job description text."
+    out = format_jd("url", content, url="")
+    assert out == content
+
+
+def test_format_jd_preserves_unicode_content():
+    """JD text may contain unicode (company names, German/French descriptions,
+    em dashes from copy-paste). Don't corrupt it."""
+    content = "Stellenbeschreibung: Senior Data Analyst — München. Gehalt €65k–€80k."
+    out = format_jd("literal", content)
+    assert out == content
+    # And with a URL:
+    out_url = format_jd("url", content, url="https://example.de/job")
+    assert "München" in out_url and "€65k–€80k" in out_url
+
+
+def test_format_jd_preserves_trailing_newlines():
+    """Don't trim content — the student may rely on a trailing newline for
+    clean markdown rendering of jd.md."""
+    content = "Line one.\nLine two.\n"
+    out = format_jd("file", content)
+    assert out.endswith("\n")
+    # URL mode should also preserve the trailing newline of the input.
+    out_url = format_jd("url", content, url="https://example.com/job")
+    assert out_url.endswith("\n")
+
+
+# ---------------------------------------------------------------------------
+# format-jd CLI subcommand (stdin → stdout transform)
+# ---------------------------------------------------------------------------
+
+
+def _run_format_jd(*args: str, stdin: str = "") -> subprocess.CompletedProcess[str]:
+    cmd = ["python", "-m", "scripts.orchestration", "format-jd", *args]
+    return subprocess.run(cmd, input=stdin, capture_output=True, text=True, check=False)
+
+
+def test_cli_format_jd_file_mode_reads_stdin_and_passes_through():
+    content = "File-mode JD.\nSecond line.\n"
+    r = _run_format_jd("--mode", "file", stdin=content)
+    assert r.returncode == 0
+    assert r.stdout == content
+
+
+def test_cli_format_jd_literal_mode_passes_through():
+    content = "Literal pasted text."
+    r = _run_format_jd("--mode", "literal", stdin=content)
+    assert r.returncode == 0
+    assert r.stdout == content
+
+
+def test_cli_format_jd_url_mode_prepends_source_url():
+    url = "https://company.com/jobs/42"
+    content = "Page text from the fetch.\n"
+    r = _run_format_jd("--mode", "url", "--url", url, stdin=content)
+    assert r.returncode == 0
+    assert r.stdout.startswith(f"Source URL: {url}\n\n")
+    assert "Page text from the fetch." in r.stdout
+
+
+def test_cli_format_jd_url_mode_without_url_flag_is_noop():
+    """Defensive: mode=url without --url should pass content through, not
+    crash. This exercises the same fallback the Python function has."""
+    content = "Content without a URL."
+    r = _run_format_jd("--mode", "url", stdin=content)
+    assert r.returncode == 0
+    assert r.stdout == content
+
+
+def test_cli_format_jd_rejects_unknown_mode():
+    """argparse `choices` should reject anything outside file/url/literal."""
+    r = _run_format_jd("--mode", "garbage", stdin="anything")
+    assert r.returncode != 0
+    assert "invalid choice" in r.stderr
+
+
+def test_cli_format_jd_reads_content_from_file_argument(tmp_path: Path):
+    """--content-file <path> is an alternative to piping via stdin. Useful
+    when the JD text is multi-KB and stdin plumbing gets awkward."""
+    jd_file = tmp_path / "fetched.txt"
+    jd_file.write_text("JD text from disk.\n", encoding="utf-8")
+    r = _run_format_jd("--mode", "literal", "--content-file", str(jd_file))
+    assert r.returncode == 0
+    assert r.stdout == "JD text from disk.\n"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #15. First v0.4 feature shaped by cohort feedback (h/t @b0glarka).

## Problem

@b0glarka ran resumasher against 4 postings yesterday, tried to re-check the exact wording of a requirement on one of them, and found the JD was gone — it only ever lived at `$RUN_DIR/jd.txt`, which gets wiped at the start of every new run. The application folder had the tailored resume, cover letter, fit assessment, research, and 3 PDFs, but no JD. They also wanted the source URL for a recruiter follow-up.

## Fix

Two parts, tested across all three JD input modes (file / literal / url).

### 1. New `format-jd` orchestration subcommand

Pure stdin → stdout transform:
- `mode=file`, `mode=literal`: content passed through unchanged
- `mode=url`: prepends `Source URL: <url>\n\n` so the posting URL is preserved alongside the fetched page text
- `mode=url` without `--url`: defensive pass-through (prefer un-headered file over crashing)

Phase 1 in `SKILL.md` now routes the JD write through this subcommand:

```bash
# file or literal:
echo -n "$CONTENT" | "$RS" orchestration format-jd --mode "$MODE" > "$RUN_DIR/jd.txt"

# url:
echo -n "$FETCHED_PAGE_TEXT" | "$RS" orchestration format-jd --mode url --url "$URL" > "$RUN_DIR/jd.txt"
```

Why the URL prepend matters: `parse_job_source` returns only the URL string for `mode=url` (not the fetched page content — that's fetched separately by the AI CLI's WebFetch tool). Without an explicit prepend, the URL itself was never persisted anywhere a student could read later. The recruiter-follow-up use case @b0glarka called out was half-broken before.

### 2. One-line `cp` at Phase 3

Right after `mkdir -p "$OUT_DIR"`:

```bash
cp "$RUN_DIR/jd.txt" "$OUT_DIR/jd.md"
```

**Placement matters.** Done at Phase 3 (not Phase 9), so the JD survives even if Phase 4 (company research), 5 (tailor), 6 (cover + prep), 7 (placeholder fill), or 8 (PDF render) hard-stops. @b0glarka explicitly argued this tradeoff in their issue's Alternatives section:

> Save the JD only on terminal success (Phase 9). Works, but Phase 3 is safer: the JD persists even if a later phase hard-stops.

## Coverage across the three JD input modes

| Mode | What `$OUT_DIR/jd.md` contains |
|------|-------------------------------|
| `file` (path to `job.md`, `jd.txt`, etc.) | file contents, unchanged |
| `literal` (pasted after the command) | pasted text, unchanged |
| `url` (`https://...`) | `Source URL: <url>\n\n` + fetched page text |

Verified by 13 new unit + CLI tests (see below).

## Tests added (13 new)

`tests/test_orchestration.py`:

**format_jd function (7 tests):**
- `test_format_jd_file_mode_passes_content_through`
- `test_format_jd_literal_mode_passes_content_through`
- `test_format_jd_url_mode_prepends_source_url_header` (exact string shape)
- `test_format_jd_url_mode_without_url_arg_defensive_fallback`
- `test_format_jd_url_mode_with_empty_url_defensive_fallback`
- `test_format_jd_preserves_unicode_content` (German/French content + URLs)
- `test_format_jd_preserves_trailing_newlines`

**format-jd CLI subcommand (6 tests):**
- `test_cli_format_jd_file_mode_reads_stdin_and_passes_through`
- `test_cli_format_jd_literal_mode_passes_through`
- `test_cli_format_jd_url_mode_prepends_source_url`
- `test_cli_format_jd_url_mode_without_url_flag_is_noop`
- `test_cli_format_jd_rejects_unknown_mode` (argparse guard)
- `test_cli_format_jd_reads_content_from_file_argument` (stdin alternative)

**Total suite:** 220 → 233, all green locally. README test badge bumped to match.

## Test plan

- [x] CI passes on all three Python versions (3.10, 3.11, 3.12)
- [x] After merge, run `/resumasher <file-path>` and confirm `jd.md` appears in the application folder with the file's contents
- [x] Run `/resumasher "Senior Data Analyst at Acme..."` (literal) and confirm `jd.md` contains the pasted text
- [x] Run `/resumasher https://example.com/jobs/42` and confirm `jd.md` starts with `Source URL: https://example.com/jobs/42`