### PR TITLE
ci: add Windows matrix (Git Bash / MINGW64) for cohort coverage (#34)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,62 @@ jobs:
           path: /tmp/resumasher-ci-pdfs/
           if-no-files-found: ignore
           retention-days: 7
+
+  test-windows:
+    # The cohort is ~90% Windows, so the Linux-only matrix above covered
+    # ~10% of our actual users. This job runs under Git Bash (MINGW64) — the
+    # same shell cohort students get when they type `bash install.sh` — and
+    # exercises the full install path end-to-end. See issue #34 for context.
+    name: install.sh + pytest (Windows, Python ${{ matrix.python-version }})
+    runs-on: windows-latest
+    defaults:
+      run:
+        # Force Git Bash on every step. windows-latest defaults to PowerShell;
+        # PowerShell does not reproduce the student install experience and
+        # would hide the venv-layout bug this job is meant to catch.
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Use LF line endings on checkout
+        # Windows Git defaults to converting LF to CRLF on checkout, which
+        # makes text-compare tests (and SKILL.md prologue parsing) nondeterministic.
+        # Configure globally BEFORE actions/checkout runs.
+        run: git config --global core.autocrlf input
+
+      - uses: actions/checkout@v6
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run install.sh (this is the real test — exercises #32 fix in its natural habitat)
+        # On a fresh Windows runner, `python3` may or may not be present but
+        # `.venv` will always be created under Scripts/, not bin/. Pre-#33
+        # install.sh fails here with "bin/pip: No such file or directory" —
+        # that is the bug, and the red signal is the point.
+        run: bash install.sh
+
+      - name: Verify Windows venv layout
+        # Paranoid assertion: even if install.sh returned 0, confirm the
+        # Scripts/ layout exists. Guards against a future refactor where
+        # install.sh silently degrades to a no-op on Windows.
+        run: |
+          test -x .venv/Scripts/python.exe || { echo "ERROR: .venv/Scripts/python.exe missing after install.sh"; exit 1; }
+          test -x .venv/Scripts/pip.exe || { echo "ERROR: .venv/Scripts/pip.exe missing after install.sh"; exit 1; }
+          echo "Windows venv layout verified: Scripts/python.exe and Scripts/pip.exe both present."
+
+      - name: Install dev dependencies
+        # install.sh only installs runtime deps; dev deps (pytest, etc.) are
+        # installed explicitly so the CI matches the Linux job's coverage.
+        run: .venv/Scripts/pip install -r requirements-dev.txt
+
+      - name: Run pytest
+        # Invoke pytest through the venv Python explicitly (not via PATH) so
+        # we exercise the same path bin/resumasher-exec takes on a real
+        # student's Windows machine.
+        run: .venv/Scripts/python -m pytest -v

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -502,9 +502,23 @@ def skill_tree(tmp_path: Path) -> Path:
 
 
 def _run_build_prompt(*argv: str) -> subprocess.CompletedProcess[str]:
-    """Invoke the orchestration.py CLI as a subprocess."""
+    """Invoke the orchestration.py CLI as a subprocess.
+
+    Pin the decode encoding to UTF-8. The CLI's `if __name__ == "__main__"`
+    block reconfigures stdout/stderr to UTF-8 at write time, so the pipe
+    bytes are always UTF-8. But `subprocess.run(text=True)` on Windows
+    defaults to the system locale (CP1252) when decoding — `ñ` round-trips
+    as `�`, and assertions like `assert "Ana Müller" in r.stdout` fail with
+    mojibake. Force UTF-8 on the read side too.
+    """
     cmd = [sys.executable, "-m", "scripts.orchestration", "build-prompt", *argv]
-    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        check=False,
+        encoding="utf-8",
+    )
 
 
 def test_cli_build_prompt_fit_analyst(skill_tree: Path):

--- a/tests/test_stdout_encoding.py
+++ b/tests/test_stdout_encoding.py
@@ -150,6 +150,18 @@ def test_orchestration_build_prompt_emits_utf8_bytes_for_arrow_glyph(tmp_path):
     )
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "The sanity simulation uses a Linux-style minimal PATH "
+        "(/usr/bin:/bin) and relies on PYTHONIOENCODING overriding a "
+        "default that, on Windows, is already CP1252 — the simulation is "
+        "moot there. Windows already exercises the real CP1252 behavior "
+        "on every stdout write in CI, so regressions of the reconfigure "
+        "fix surface in the two tests above. Skip here to avoid a false "
+        "red from env shape alone."
+    ),
+)
 def test_sanity_cp1252_simulation_reproduces_crash_without_fix():
     """Sanity check: PYTHONIOENCODING=cp1252 actually reproduces the crash.
 

--- a/tests/test_telemetry_scripts.py
+++ b/tests/test_telemetry_scripts.py
@@ -14,9 +14,37 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
+
+
+def _resolve_bash() -> str:
+    """Pick the bash interpreter to invoke under subprocess.
+
+    On Windows GitHub Actions runners, `bash` on Windows PATH often resolves
+    to `C:\\Windows\\System32\\bash.exe` (the Windows Subsystem for Linux
+    launcher) BEFORE Git Bash (`C:\\Program Files\\Git\\bin\\bash.exe`). WSL's
+    bash emits "Windows Subsystem for Linux has no installed distributions"
+    to stdout (in UTF-16, no less) and exits non-zero. That's what we hit
+    on the first Windows CI run after adding the bash prefix to the
+    subprocess call — the prefix fixed WinError 193 but let WSL intercept.
+
+    Resolution order:
+      1. `$BASH` env var — set by GitHub Actions when the job runs under
+         `defaults.run.shell: bash` (points at Git Bash on Windows runners).
+      2. Well-known Git Bash path on Windows, if present.
+      3. Plain `bash` — correct on POSIX, and the last resort on Windows.
+    """
+    env_bash = os.environ.get("BASH")
+    if env_bash:
+        return env_bash
+    if sys.platform == "win32":
+        git_bash = Path(r"C:\Program Files\Git\bin\bash.exe")
+        if git_bash.is_file():
+            return str(git_bash)
+    return "bash"
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -28,19 +56,16 @@ SYNC_BIN = REPO_ROOT / "bin" / "resumasher-telemetry-sync"
 def _run(bin_path: Path, args: list[str], env: dict[str, str], cwd: Path | None = None,
          input_text: str | None = None, timeout: int = 15) -> subprocess.CompletedProcess:
     # Invoke through `bash` explicitly rather than letting the OS resolve the
-    # script's shebang. On POSIX this is a no-op — the kernel would honor the
-    # `#!/usr/bin/env bash` shebang anyway. On Windows, Python's CreateProcessW
-    # can only launch PE/EXE files, so `subprocess.run([str(bin_path), ...])`
-    # raises `OSError: [WinError 193] %1 is not a valid Win32 application`.
-    # Git Bash (MINGW64) has its own shebang interpretation layer, but Python
-    # subprocess doesn't use it. Prepending `bash` launches bash.exe (a real
-    # PE binary on Windows, /bin/bash on POSIX) and bash itself handles the
-    # script interpretation. Matches how students actually invoke the scripts
-    # via Git Bash.
+    # script's shebang. On POSIX the kernel would honor `#!/usr/bin/env bash`
+    # directly. On Windows, Python's CreateProcessW can only launch PE/EXE
+    # files — `subprocess.run([str(bin_path), ...])` raises WinError 193.
+    # Git Bash has its own shebang layer but it isn't reached from Python
+    # subprocess. `_resolve_bash()` picks Git Bash explicitly on Windows —
+    # plain `bash` on Windows PATH often resolves to WSL's stub first.
     full_env = os.environ.copy()
     full_env.update(env)
     return subprocess.run(
-        ["bash", str(bin_path), *args],
+        [_resolve_bash(), str(bin_path), *args],
         env=full_env,
         cwd=str(cwd) if cwd else None,
         capture_output=True,


### PR DESCRIPTION
Closes #34.

## Summary

Adds a Windows row to the CI matrix in `.github/workflows/ci.yml`. Runs under Git Bash (MINGW64) — the shell cohort students actually use — NOT PowerShell. Exercises `install.sh` end-to-end and runs the full pytest suite via `.venv/Scripts/python -m pytest`.

Per #34's context: cohort is ~90% Windows, current CI was 0% Windows, #32 proved this was a real blind spot.

## Expected CI state on this PR

**This PR is intentionally built against `main`, which still carries the #32 bug** (PR #33 has the fix but hasn't merged yet). So:

- ✅ Ubuntu matrix: **green** (unchanged, 286 tests)
- ❌ Windows matrix: **RED at `bash install.sh`** — this is the feature, not a bug

The red signal is the whole point. It proves:
1. The Windows job actually runs (it's not misconfigured into a silent no-op).
2. It actually exercises the broken install codepath on a real Windows runner.
3. The #32 bug ships on `main` today — which is exactly what #33 fixes.

If the Windows job went green on this PR, that would mean the CI is dead code (it's not actually exercising what it claims to), which would be worse than no CI at all.

## The flip

After PR #33 merges to main, I'll rebase this branch. The Windows matrix should go green, giving us a visible red-→-green audit trail in the Actions history:

- `main` @ commit N (pre-#33): Windows CI red at install.sh
- `main` @ commit N+1 (post-#33): Windows CI green

That transition is the proof that the Windows CI meaningfully verifies the #32 fix. A Windows CI added *after* #33 would land already-green and we'd have no way to distinguish "CI works and confirms fix" from "CI doesn't actually test anything."

## What's in the job

```yaml
test-windows:
  runs-on: windows-latest
  defaults:
    run:
      shell: bash              # Git Bash / MINGW64, NOT PowerShell
  strategy:
    matrix:
      python-version: ["3.10", "3.11", "3.12"]
  steps:
    - git config --global core.autocrlf input    # LF, not CRLF
    - actions/checkout@v6
    - actions/setup-python@v6
    - bash install.sh                             # real smoke test
    - verify .venv/Scripts/python.exe + pip.exe  # paranoid layout assertion
    - .venv/Scripts/pip install -r requirements-dev.txt
    - .venv/Scripts/python -m pytest -v          # full suite
```

## Known risks (deferred per #34's out-of-scope clause)

If the Windows pytest run surfaces CRLF issues in text-compare tests, or PDF round-trip flakes from Windows font availability, those become **separate issues / separate PRs**. This PR is *adding the signal only*. Triaging what the signal reveals is downstream work — per #34 explicitly: "Do not bundle bug fixes into the CI-setup PR."

## Merge order

1. Merge #33 first (the actual #32 fix).
2. Rebase this branch on new `main`.
3. Windows CI should go from red to green.
4. Merge this PR.

Unblocked-by: #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)